### PR TITLE
OO-37: Move repo ownership to SKOOP

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @kartverket/skip
-/.security/ @omaen
+* @kartverket/skoop
+/.security/ @okpedersen


### PR DESCRIPTION
SKOOP will replace SKIP as repo admin too.